### PR TITLE
fix: bypass throttling for health probes

### DIFF
--- a/s3proxy/cmd/main.go
+++ b/s3proxy/cmd/main.go
@@ -94,11 +94,10 @@ func runServer(flags cmdFlags, log *logger.Logger) error {
 		throttler := router.NewThrottlingMiddleware(throttling, 10*time.Second)
 		// Explicitly convert h to http.Handler so it can be used with Throttle
 		hMdw = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			throttler.Throttle(h).ServeHTTP(w, r)
-		})
-	}
-
-	server := http.Server{
+                        if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" {
+                                h.ServeHTTP(w, r)
+                                return
+                        }
 		Addr:    fmt.Sprintf("%s:%d", flags.ip, defaultPort),
 		Handler: hMdw,
 		// Disable HTTP/2. Serving HTTP/2 will cause some clients to use HTTP/2.

--- a/s3proxy/cmd/main.go
+++ b/s3proxy/cmd/main.go
@@ -94,10 +94,15 @@ func runServer(flags cmdFlags, log *logger.Logger) error {
 		throttler := router.NewThrottlingMiddleware(throttling, 10*time.Second)
 		// Explicitly convert h to http.Handler so it can be used with Throttle
 		hMdw = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-                        if r.URL.Path == "/healthz" || r.URL.Path == "/readyz" {
-                                h.ServeHTTP(w, r)
-                                return
-                        }
+			if isHealthCheckRequest(r) {
+				h.ServeHTTP(w, r)
+				return
+			}
+			throttler.Throttle(h).ServeHTTP(w, r)
+		})
+	}
+
+	server := http.Server{
 		Addr:    fmt.Sprintf("%s:%d", flags.ip, defaultPort),
 		Handler: hMdw,
 		// Disable HTTP/2. Serving HTTP/2 will cause some clients to use HTTP/2.
@@ -123,6 +128,10 @@ func runServer(flags cmdFlags, log *logger.Logger) error {
 
 	log.Warn("TLS is disabled")
 	return server.ListenAndServe()
+}
+
+func isHealthCheckRequest(r *http.Request) bool {
+	return r.Method == http.MethodGet && (r.URL.Path == "/healthz" || r.URL.Path == "/readyz")
 }
 
 func parseFlags() (cmdFlags, error) {

--- a/s3proxy/cmd/main_test.go
+++ b/s3proxy/cmd/main_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) Intrinsec 2026
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsHealthCheckRequest(t *testing.T) {
+	tests := map[string]struct {
+		method string
+		path   string
+		want   bool
+	}{
+		"healthz": {
+			method: http.MethodGet,
+			path:   "/healthz",
+			want:   true,
+		},
+		"readyz": {
+			method: http.MethodGet,
+			path:   "/readyz",
+			want:   true,
+		},
+		"wrong method": {
+			method: http.MethodPost,
+			path:   "/healthz",
+		},
+		"wrong path": {
+			method: http.MethodGet,
+			path:   "/bucket/key",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+
+			assert.Equal(t, tc.want, isHealthCheckRequest(req))
+		})
+	}
+}


### PR DESCRIPTION
The throttling middleware is currently applied to all endpoints, including `/healthz` and `/readyz`. When the proxy reaches its maximum concurrent requests (via `S3PROXY_THROTTLING_REQUESTSMAX`), Kubernetes health probes get stuck in the queue and time out, causing the pod to be restarted by Kubernetes (Exit Code 2).

This pull request modifies the router handler to bypass the throttling middleware for health check endpoints, ensuring that probes succeed under high load.