### PR TITLE
Use router KEK for object encryption

### DIFF
--- a/s3proxy/internal/router/BUILD.bazel
+++ b/s3proxy/internal/router/BUILD.bazel
@@ -22,5 +22,10 @@ go_test(
     name = "router_test",
     srcs = ["router_test.go"],
     embed = [":router"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//s3proxy/internal/crypto",
+        "@com_github_sirupsen_logrus//:logrus",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/s3proxy/internal/router/handler.go
+++ b/s3proxy/internal/router/handler.go
@@ -16,33 +16,16 @@ import (
 	"time"
 
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	"github.com/intrinsec/s3proxy/internal/config"
 	"github.com/intrinsec/s3proxy/internal/s3"
 	logger "github.com/sirupsen/logrus"
 )
 
-// getKEK retrieves the key encryption key
-func getKEK() ([32]byte, error) {
-	encryptKey, err := config.GetEncryptKey()
-	if err != nil {
-		return [32]byte{}, fmt.Errorf("getting encryption key: %w", err)
-	}
-	return generateKEKFromString(encryptKey), nil
-}
-
-func handleGetObject(client *s3.Client, key string, bucket string, log *logger.Logger) http.HandlerFunc {
+func handleGetObject(client s3Client, key string, bucket string, kek [32]byte, log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		log.WithField("path", req.URL.Path).WithField("method", req.Method).WithField("host", req.Host).Debug("intercepting")
 		if req.Header.Get("Range") != "" {
 			log.Error("GetObject Range header unsupported")
 			http.Error(w, "s3proxy currently does not support Range headers", http.StatusNotImplemented)
-			return
-		}
-
-		kek, err := getKEK()
-		if err != nil {
-			log.WithError(err).Error("failed to get KEK")
-			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
 
@@ -67,16 +50,9 @@ func handleGetObject(client *s3.Client, key string, bucket string, log *logger.L
 	}
 }
 
-func handlePutObject(client *s3.Client, key string, bucket string, log *logger.Logger) http.HandlerFunc {
+func handlePutObject(client s3Client, key string, bucket string, kek [32]byte, log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		log.WithField("path", req.URL.Path).WithField("method", req.Method).WithField("host", req.Host).Debug("intercepting")
-
-		kek, err := getKEK()
-		if err != nil {
-			log.WithError(err).Error("failed to get KEK")
-			http.Error(w, "internal server error", http.StatusInternalServerError)
-			return
-		}
 
 		body, err := readBody(req.Body, req.ContentLength)
 		if err != nil {

--- a/s3proxy/internal/router/object.go
+++ b/s3proxy/internal/router/object.go
@@ -102,7 +102,6 @@ func (o object) get(w http.ResponseWriter, r *http.Request) {
 		}
 
 		plaintext, err = crypto.Decrypt(body, encryptedDEK, o.kek)
-		body = nil
 		if err != nil {
 			o.log.WithField("requestID", requestID).WithField("error", err).Error("GetObject decrypting response")
 			http.Error(w, "failed to decrypt object", http.StatusInternalServerError)
@@ -137,7 +136,6 @@ func (o object) put(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	o.data = nil
 	o.metadata[dekTag] = hex.EncodeToString(encryptedDEK)
 
 	output, err := o.client.PutObject(context.WithoutCancel(r.Context()), o.bucket, o.key, o.tags, o.contentType, o.objectLockLegalHoldStatus, o.objectLockMode, o.sseCustomerAlgorithm, o.sseCustomerKey, o.sseCustomerKeyMD5, o.objectLockRetainUntilDate, o.metadata, ciphertext)

--- a/s3proxy/internal/router/router.go
+++ b/s3proxy/internal/router/router.go
@@ -344,8 +344,11 @@ func put(h http.HandlerFunc) http.HandlerFunc {
 }
 
 func (r Router) getHandler(req *http.Request, client s3Client, matchingPath bool, key, bucket string) http.Handler {
-	s3Client, ok := client.(*s3.Client)
-	if !ok {
+	forwardHandler := func() http.Handler {
+		s3Client, ok := client.(*s3.Client)
+		if ok {
+			return handleForwards(s3Client, r.log)
+		}
 		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 		})
@@ -353,7 +356,7 @@ func (r Router) getHandler(req *http.Request, client s3Client, matchingPath bool
 
 	// Forward if path doesn't match
 	if !matchingPath {
-		return handleForwards(s3Client, r.log)
+		return forwardHandler()
 	}
 
 	// Check multipart operations first (if not forwarding them)
@@ -365,16 +368,16 @@ func (r Router) getHandler(req *http.Request, client s3Client, matchingPath bool
 	switch req.Method {
 	case http.MethodGet:
 		if !isUnwantedGetEndpoint(req.URL.Query()) {
-			return handleGetObject(s3Client, key, bucket, r.log)
+			return handleGetObject(client, key, bucket, r.kek, r.log)
 		}
 	case http.MethodPut:
 		if !isUnwantedPutEndpoint(req.Header, req.URL.Query()) {
-			return handlePutObject(s3Client, key, bucket, r.log)
+			return handlePutObject(client, key, bucket, r.kek, r.log)
 		}
 	}
 
 	// Forward all other requests
-	return handleForwards(s3Client, r.log)
+	return forwardHandler()
 }
 
 func (r Router) getMultipartHandler(req *http.Request) http.Handler {

--- a/s3proxy/internal/router/router_test.go
+++ b/s3proxy/internal/router/router_test.go
@@ -6,13 +6,50 @@ SPDX-License-Identifier: AGPL-3.0-only
 package router
 
 import (
+	"bytes"
+	"context"
+	"encoding/hex"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/intrinsec/s3proxy/internal/crypto"
+	logger "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type recordingS3Client struct {
+	body         []byte
+	metadata     map[string]string
+	getObjectOut *s3.GetObjectOutput
+}
+
+func (c *recordingS3Client) GetObject(context.Context, string, string, string, string, string, string) (*s3.GetObjectOutput, error) {
+	if c.getObjectOut != nil {
+		return c.getObjectOut, nil
+	}
+	return &s3.GetObjectOutput{}, nil
+}
+
+func (c *recordingS3Client) PutObject(_ context.Context, _, _, _, _, _, _, _, _, _ string, _ time.Time, metadata map[string]string, body []byte) (*s3.PutObjectOutput, error) {
+	c.body = append([]byte(nil), body...)
+	c.metadata = make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		c.metadata[key] = value
+	}
+	return &s3.PutObjectOutput{}, nil
+}
+
+func testLogger() *logger.Logger {
+	log := logger.New()
+	log.SetOutput(io.Discard)
+	return log
+}
 
 func TestValidateContentMD5(t *testing.T) {
 	tests := map[string]struct {
@@ -108,4 +145,74 @@ func TestReadBodyReturnsErrorOnShortBody(t *testing.T) {
 	_, err := readBody(strings.NewReader("hi"), 5)
 
 	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestPutObjectUsesRouterKEK(t *testing.T) {
+	expectedKEK := generateKEKFromString("expected encryption key")
+	client := &recordingS3Client{}
+	router := Router{kek: expectedKEK, log: testLogger()}
+	req := httptest.NewRequest(http.MethodPut, "/bucket/key", bytes.NewReader([]byte("secret payload")))
+	rec := httptest.NewRecorder()
+
+	router.getHandler(req, client, true, "key", "bucket").ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	rawEncryptedDEK, ok := client.metadata[dekTag]
+	require.True(t, ok)
+	encryptedDEK, err := hex.DecodeString(rawEncryptedDEK)
+	require.NoError(t, err)
+	plaintext, err := crypto.Decrypt(client.body, encryptedDEK, expectedKEK)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("secret payload"), plaintext)
+
+	_, err = crypto.Decrypt(client.body, encryptedDEK, [32]byte{})
+	assert.Error(t, err)
+}
+
+func TestGetObjectUsesRouterKEK(t *testing.T) {
+	expectedKEK := generateKEKFromString("expected encryption key")
+	client := newEncryptedGetObjectClient(t, expectedKEK, []byte("secret payload"))
+	router := Router{kek: expectedKEK, log: testLogger()}
+	req := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)
+	rec := httptest.NewRecorder()
+
+	router.getHandler(req, client, true, "key", "bucket").ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "secret payload", rec.Body.String())
+}
+
+func TestGetObjectFailsWithWrongRouterKEK(t *testing.T) {
+	storedObjectKEK := generateKEKFromString("old encryption key")
+	routerKEK := generateKEKFromString("new encryption key")
+	client := newEncryptedGetObjectClient(t, storedObjectKEK, []byte("secret payload"))
+	router := Router{kek: routerKEK, log: testLogger()}
+	req := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)
+	rec := httptest.NewRecorder()
+
+	router.getHandler(req, client, true, "key", "bucket").ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "failed to decrypt object")
+}
+
+func newEncryptedGetObjectClient(t *testing.T, kek [32]byte, plaintext []byte) *recordingS3Client {
+	t.Helper()
+
+	ciphertext, encryptedDEK, err := crypto.Encrypt(plaintext, kek)
+	require.NoError(t, err)
+
+	return &recordingS3Client{
+		getObjectOut: &s3.GetObjectOutput{
+			Body:          io.NopCloser(bytes.NewReader(ciphertext)),
+			ContentLength: awsInt64(int64(len(ciphertext))),
+			Metadata: map[string]string{
+				dekTag: hex.EncodeToString(encryptedDEK),
+			},
+		},
+	}
+}
+
+func awsInt64(v int64) *int64 {
+	return &v
 }


### PR DESCRIPTION
## Summary

- pass the KEK computed by `Router.New()` into GET/PUT object handlers
- remove per-request environment lookup for `S3PROXY_ENCRYPT_KEY` inside handlers
- keep forwarding paths requiring a concrete S3 client, while allowing object handlers to use the internal S3 client interface
- add a regression test proving PUT encryption uses the router KEK and cannot be decrypted with a zero KEK

Closes #21.

## Validation

- go test ./...
- CGO_ENABLED=0 GOOS=linux go build -o /tmp/s3proxy-kek ./s3proxy/cmd

Not run: `bazel test //s3proxy/internal/router:router_test` because `bazel` is not installed in this local environment.
