### PR TITLE
Add golangci-lint CI workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,30 @@
+name: Go lint
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4


### PR DESCRIPTION
## Summary

- add a dedicated GitHub Actions workflow for golangci-lint
- run it on pull requests to main, pushes to main, and manual dispatch
- use Go from go.mod and golangci-lint v2.11.4

## Validation

- golangci-lint run

Note: local YAML validation with ruby was not run because ruby is not installed in this environment.
