### PR TITLE
Add opt-in decryption fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ S3Proxy can be easily deployed on Kubernetes using its official Helm chart locat
 
 Key configurable parameters via `values.yaml` include:
 - `replicaCount`: Number of S3Proxy instances to run.
+- `deploymentStrategy`: Kubernetes Deployment rollout strategy (`RollingUpdate` by default, or `Recreate`).
 - `image`: Docker image repository and tag for S3Proxy.
 - `args`: Command-line arguments passed to the S3Proxy binary (e.g., `--no-tls` to disable TLS, `--level` for log verbosity).
 - `cert`: Configuration for CertManager integration to automatically provision TLS certificates.
 - `config`: Settings for the S3 backend, including `host`, `throttling` (maximum requests per second), `accessKey`, `secretKey`, and `encryptKey` (the KEK).
+- `extraEnv`: Additional environment variables, such as `S3PROXY_DECRYPTION_FALLBACK` for temporary fallback decryption.
 - `service`: Kubernetes Service configuration (defaults to `ClusterIP` on port `4433`).
 - `ingress`: Optional Ingress configuration for external access.
 - `resources`: CPU and memory limits and requests for the S3Proxy pods.

--- a/charts/s3proxy/templates/deployment.yaml
+++ b/charts/s3proxy/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "s3proxy.selectorLabels" . | nindent 6 }}
@@ -58,6 +60,9 @@ spec:
           {{- if .Values.config.throttling }}
           - name: S3PROXY_THROTTLING_REQUESTSMAX
             value: {{ .Values.config.throttling | quote }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           ports:
             - name: http

--- a/charts/s3proxy/values.yaml
+++ b/charts/s3proxy/values.yaml
@@ -1,5 +1,11 @@
 replicaCount: 1
 
+deploymentStrategy:
+  type: RollingUpdate
+  # rollingUpdate:
+  #   maxUnavailable: 25%
+  #   maxSurge: 25%
+
 image:
   repository: ghcr.io/intrinsec/s3proxy
   pullPolicy: Always
@@ -32,6 +38,10 @@ valsSecret: {}
 
 podAnnotations: {}
 podLabels: {}
+
+extraEnv: []
+# - name: S3PROXY_DECRYPTION_FALLBACK
+#   value: "true"
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/s3proxy/internal/config/config.go
+++ b/s3proxy/internal/config/config.go
@@ -44,3 +44,7 @@ func GetEncryptKey() (string, error) {
 func GetThrottlingRequestsMax() int {
 	return k.Int("s3proxy.throttling.requestsmax")
 }
+
+func GetDecryptionFallbackEnabled() bool {
+	return k.Bool("s3proxy.decryption.fallback")
+}

--- a/s3proxy/internal/router/handler.go
+++ b/s3proxy/internal/router/handler.go
@@ -20,7 +20,7 @@ import (
 	logger "github.com/sirupsen/logrus"
 )
 
-func handleGetObject(client s3Client, key string, bucket string, kek [32]byte, log *logger.Logger) http.HandlerFunc {
+func handleGetObject(client s3Client, key string, bucket string, kek [32]byte, decryptionFallback bool, log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		log.WithField("path", req.URL.Path).WithField("method", req.Method).WithField("host", req.Host).Debug("intercepting")
 		if req.Header.Get("Range") != "" {
@@ -35,16 +35,19 @@ func handleGetObject(client s3Client, key string, bucket string, kek [32]byte, l
 		}
 
 		obj := object{
-			kek:                  kek,
-			client:               client,
-			key:                  key,
-			bucket:               bucket,
-			query:                req.URL.Query(),
-			versionID:            versionID,
-			sseCustomerAlgorithm: req.Header.Get("x-amz-server-side-encryption-customer-algorithm"),
-			sseCustomerKey:       req.Header.Get("x-amz-server-side-encryption-customer-key"),
-			sseCustomerKeyMD5:    req.Header.Get("x-amz-server-side-encryption-customer-key-MD5"),
-			log:                  log,
+			kek:                kek,
+			decryptionFallback: decryptionFallback,
+			client:             client,
+			key:                key,
+			bucket:             bucket,
+			query:              req.URL.Query(),
+			versionID:          versionID,
+			sseCustomerAlgorithm: req.Header.Get(
+				"x-amz-server-side-encryption-customer-algorithm",
+			),
+			sseCustomerKey:    req.Header.Get("x-amz-server-side-encryption-customer-key"),
+			sseCustomerKeyMD5: req.Header.Get("x-amz-server-side-encryption-customer-key-MD5"),
+			log:               log,
 		}
 		get(obj.get)(w, req)
 	}

--- a/s3proxy/internal/router/object.go
+++ b/s3proxy/internal/router/object.go
@@ -38,6 +38,7 @@ var (
 // object bundles data to implement http.Handler methods that use data from incoming requests.
 type object struct {
 	kek                       [32]byte
+	decryptionFallback        bool
 	client                    s3Client
 	key                       string
 	bucket                    string
@@ -101,7 +102,7 @@ func (o object) get(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		plaintext, err = crypto.Decrypt(body, encryptedDEK, o.kek)
+		plaintext, err = o.decryptObject(body, encryptedDEK, requestID)
 		if err != nil {
 			o.log.WithField("requestID", requestID).WithField("error", err).Error("GetObject decrypting response")
 			http.Error(w, "failed to decrypt object", http.StatusInternalServerError)
@@ -123,6 +124,22 @@ func (o object) get(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+}
+
+func (o object) decryptObject(ciphertext, encryptedDEK []byte, requestID string) ([]byte, error) {
+	plaintext, err := crypto.Decrypt(ciphertext, encryptedDEK, o.kek)
+	if err == nil || !o.decryptionFallback {
+		return plaintext, err
+	}
+
+	o.log.WithField("requestID", requestID).WithField("key", o.key).WithField("bucket", o.bucket).WithField("error", err).Warn("primary KEK failed, retrying decryption fallback")
+	plaintext, fallbackErr := crypto.Decrypt(ciphertext, encryptedDEK, [32]byte{})
+	if fallbackErr != nil {
+		return nil, err
+	}
+
+	o.log.WithField("requestID", requestID).WithField("key", o.key).WithField("bucket", o.bucket).Warn("object decrypted using fallback key path")
+	return plaintext, nil
 }
 
 // put is a http.HandlerFunc that implements the PUT method for objects.

--- a/s3proxy/internal/router/router.go
+++ b/s3proxy/internal/router/router.go
@@ -368,7 +368,7 @@ func (r Router) getHandler(req *http.Request, client s3Client, matchingPath bool
 	switch req.Method {
 	case http.MethodGet:
 		if !isUnwantedGetEndpoint(req.URL.Query()) {
-			return handleGetObject(client, key, bucket, r.kek, r.log)
+			return handleGetObject(client, key, bucket, r.kek, config.GetDecryptionFallbackEnabled(), r.log)
 		}
 	case http.MethodPut:
 		if !isUnwantedPutEndpoint(req.Header, req.URL.Query()) {

--- a/s3proxy/internal/router/router_test.go
+++ b/s3proxy/internal/router/router_test.go
@@ -196,6 +196,26 @@ func TestGetObjectFailsWithWrongRouterKEK(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "failed to decrypt object")
 }
 
+func TestGetObjectUsesDecryptionFallback(t *testing.T) {
+	routerKEK := generateKEKFromString("configured encryption key")
+	client := newEncryptedGetObjectClient(t, [32]byte{}, []byte("secret payload"))
+	obj := object{
+		kek:                routerKEK,
+		decryptionFallback: true,
+		client:             client,
+		key:                "key",
+		bucket:             "bucket",
+		log:                testLogger(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)
+	rec := httptest.NewRecorder()
+
+	obj.get(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "secret payload", rec.Body.String())
+}
+
 func newEncryptedGetObjectClient(t *testing.T, kek [32]byte, plaintext []byte) *recordingS3Client {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- add an opt-in `S3PROXY_DECRYPTION_FALLBACK` path for GET object decryption
- retry only DEK unwrap/decryption metadata path after the primary KEK fails; payload decryption still happens once on the successful path
- expose generic Helm `extraEnv` instead of a dedicated fallback chart value
- add configurable Deployment strategy (`RollingUpdate` by default, supports `Recreate`)
- document the new Helm values and add regression coverage

## Usage

```yaml
extraEnv:
  - name: S3PROXY_DECRYPTION_FALLBACK
    value: "true"

deploymentStrategy:
  type: Recreate
```

## Validation

- go test ./...
- golangci-lint run
- CGO_ENABLED=0 GOOS=linux go build -o /tmp/s3proxy-decryption-fallback ./s3proxy/cmd
- helm template test charts/s3proxy
- helm template test charts/s3proxy --set deploymentStrategy.type=Recreate --set-string extraEnv[0].name=S3PROXY_DECRYPTION_FALLBACK --set-string extraEnv[0].value=true
