### PR TITLE
fix(s3): omit empty x-amz-tagging header for B2 compatibility

### DIFF
--- a/s3proxy/internal/s3/s3.go
+++ b/s3proxy/internal/s3/s3.go
@@ -226,10 +226,14 @@ func (c Client) PutObject(ctx context.Context, bucket, key, tags, contentType, o
 		Bucket:                    &bucket,
 		Key:                       &key,
 		Body:                      bytes.NewReader(body),
-		Tagging:                   &tags,
 		Metadata:                  metadata,
 		ContentType:               &contentType,
 		ObjectLockLegalHoldStatus: types.ObjectLockLegalHoldStatus(objectLockLegalHoldStatus),
+	}
+	// Only forward Tagging when the client supplied a non-empty value. Some S3-compatible
+	// backends (e.g. Backblaze B2) reject any presence of x-amz-tagging, even when empty.
+	if tags != "" {
+		putObjectInput.Tagging = &tags
 	}
 	if sseCustomerAlgorithm != "" {
 		putObjectInput.SSECustomerAlgorithm = &sseCustomerAlgorithm


### PR DESCRIPTION
## Summary
- Stop sending `x-amz-tagging` when client supplied no tags
- Unblocks Backblaze B2 (and other non-AWS backends) that reject the empty header

Fixes #34.

## Root cause
`s3proxy/internal/s3/s3.go` always assigned `Tagging: &tags` on `PutObjectInput`, even when `tags == ""`. The AWS SDK then emits `x-amz-tagging:` on the wire. AWS S3 tolerates this; B2 rejects with `InvalidArgument: Unsupported header 'x-amz-tagging' received for this API call.`

## Change
Guard the assignment behind `if tags != ""`, matching the existing pattern used for `SSECustomerAlgorithm`, `SSECustomerKey`, etc.

## Test plan
- [x] `golangci-lint run ./...` — clean
- [x] `go test ./...` — 82 passed in 7 packages
- [ ] Manual: verify against B2 endpoint reproducing #34 setup
- [ ] Manual: verify AWS S3 still accepts a PUT with explicit `x-amz-tagging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)