### PR TITLE
feat(chart)!: ship dashboard as GrafanaDashboard CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Two version streams move independently:
 
 ## [Unreleased]
 
+### Chart
+
+- **`chart/1.9.0`** — Replace the bundled Grafana dashboard `ConfigMap`
+  with a `GrafanaDashboard` CRD (`grafana.integreatly.org/v1beta1`)
+  reconciled by grafana-operator. New `grafanaDashboard.instanceSelector`,
+  `allowCrossNamespaceImport`, `folder`, `resyncPeriod` knobs; removed
+  the sidecar-only `grafanaDashboard.label`. **Breaking** for installs
+  that relied on the dashboard sidecar — switch to grafana-operator or
+  pin the chart to `1.8.x`.
+
 ## [1.8.1] — 2026-05-20
 
 Patch release. Fixes B2 (and other non-AWS S3-compatible backends)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The project is a hardened fork of the original [edgelesssys/constellation](https
 - **S3-compatible** — works with any backend that speaks S3 v4 (AWS, Scaleway, MinIO, Wasabi, Ceph, …).
 - **Secure defaults** — multipart uploads blocked, HTTPS upstream, request body capped, optional concurrency throttle.
 - **Production observability** — Prometheus metrics on `/metrics`, four shipped alerts, OTLP/HTTP traces with `slog` log/trace correlation, ready-to-import Grafana dashboard.
-- **Packaged Helm chart** — OCI-published, with opt-in `ServiceMonitor` / `PrometheusRule` / dashboard `ConfigMap`.
+- **Packaged Helm chart** — OCI-published, with opt-in `ServiceMonitor` / `PrometheusRule` / `GrafanaDashboard` CRD.
 
 ---
 
@@ -283,7 +283,7 @@ Top-level value keys:
 | `autoscaling` | disabled | HPA on CPU/memory. |
 | `serviceMonitor` | disabled | Prometheus Operator scrape config. |
 | `prometheusRule` | disabled | Alert bundle. |
-| `grafanaDashboard` | disabled | Dashboard `ConfigMap` (grafana-operator / sidecar). |
+| `grafanaDashboard` | disabled | `GrafanaDashboard` CRD (`grafana.integreatly.org/v1beta1`, grafana-operator). |
 
 A complete observability rollout looks like:
 
@@ -301,6 +301,10 @@ prometheusRule:
     highLatencySeconds: 2
 grafanaDashboard:
   enabled: true
+  folder: s3proxy
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
 config:
   host: s3.fr-par.scw.cloud
   otlpTracesEndpoint: https://otel-collector.observability.svc.cluster.local:4318/v1/traces

--- a/charts/s3proxy/Chart.yaml
+++ b/charts/s3proxy/Chart.yaml
@@ -18,5 +18,5 @@ maintainers:
 annotations:
   org.opencontainers.image.source: "https://github.com/intrinsec/s3proxy/"
 type: application
-version: 1.8.2
+version: 1.9.0
 appVersion: "1.8.1"

--- a/charts/s3proxy/templates/grafana-dashboard.yaml
+++ b/charts/s3proxy/templates/grafana-dashboard.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.grafanaDashboard.enabled }}
-apiVersion: v1
-kind: ConfigMap
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
 metadata:
   name: {{ include "s3proxy.fullname" . }}-dashboard
   {{- with .Values.grafanaDashboard.namespace }}
@@ -8,7 +8,6 @@ metadata:
   {{- end }}
   labels:
     {{- include "s3proxy.labels" . | nindent 4 }}
-    {{ .Values.grafanaDashboard.label | default "grafana_dashboard" }}: "1"
     {{- with .Values.grafanaDashboard.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -16,7 +15,17 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-data:
-  s3proxy.json: |-
+spec:
+  allowCrossNamespaceImport: {{ .Values.grafanaDashboard.allowCrossNamespaceImport }}
+  {{- with .Values.grafanaDashboard.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.grafanaDashboard.resyncPeriod }}
+  resyncPeriod: {{ . }}
+  {{- end }}
+  instanceSelector:
+    matchLabels:
+      {{- toYaml .Values.grafanaDashboard.instanceSelector.matchLabels | nindent 6 }}
+  json: |-
 {{ .Files.Get "dashboards/s3proxy.json" | indent 4 }}
 {{- end }}

--- a/charts/s3proxy/values.schema.json
+++ b/charts/s3proxy/values.schema.json
@@ -194,15 +194,29 @@
     "grafanaDashboard": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Opt-in ConfigMap shipping the bundled Grafana dashboard.",
+      "description": "Opt-in GrafanaDashboard CRD (grafana.integreatly.org/v1beta1) shipping the bundled dashboard. Requires grafana-operator.",
       "properties": {
         "enabled": { "type": "boolean" },
         "namespace": { "type": "string" },
-        "label": { "type": "string", "minLength": 1 },
+        "allowCrossNamespaceImport": { "type": "boolean" },
+        "folder": { "type": "string" },
+        "resyncPeriod": { "type": "string", "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$" },
+        "instanceSelector": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "matchLabels": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": { "type": "string" }
+            }
+          },
+          "required": ["matchLabels"]
+        },
         "labels": { "type": "object" },
         "annotations": { "type": "object" }
       },
-      "required": ["enabled"]
+      "required": ["enabled", "instanceSelector"]
     },
     "extraVolumes": { "type": "array" },
     "extraVolumeMounts": { "type": "array" },

--- a/charts/s3proxy/values.yaml
+++ b/charts/s3proxy/values.yaml
@@ -168,17 +168,23 @@ prometheusRule:
     serviceDown: 2m
     highCrashRate: 5m
 
-# Grafana dashboard ConfigMap. When enabled the chart ships a ConfigMap
-# carrying the s3proxy dashboard JSON, labeled so the grafana-operator /
-# dashboard sidecar picks it up automatically.
-# Requires either grafana-operator OR the official Grafana chart with the
-# dashboard sidecar enabled (`sidecar.dashboards.enabled=true`).
+# Grafana dashboard CRD. When enabled the chart ships a `GrafanaDashboard`
+# (`grafana.integreatly.org/v1beta1`) carrying the s3proxy dashboard JSON.
+# Requires grafana-operator to be installed in the cluster.
 grafanaDashboard:
   enabled: false
-  # namespace: monitoring                # where the ConfigMap should be created
-  label: grafana_dashboard               # label key the Grafana sidecar watches
-  labels: {}                             # extra labels on the ConfigMap
-  annotations: {}                        # extra annotations on the ConfigMap
+  # namespace: monitoring                # where the GrafanaDashboard is created
+  allowCrossNamespaceImport: true        # let a Grafana in another namespace pick it up
+  # folder: "s3proxy"                    # target folder in Grafana (empty = General)
+  # resyncPeriod: 5m                     # operator reconciliation cadence
+  # instanceSelector.matchLabels picks the target Grafana CR. Default value
+  # matches the `dashboards: grafana` selector used by the upstream
+  # grafana-operator examples. Tune to whatever label your Grafana CR carries.
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  labels: {}                             # extra labels on the GrafanaDashboard
+  annotations: {}                        # extra annotations on the GrafanaDashboard
 
 # Additional volumes on the output Deployment definition.
 extraVolumes: []


### PR DESCRIPTION
## Summary

Replaces the bundled Grafana dashboard `ConfigMap` (consumed by the grafana
sidecar) with a `GrafanaDashboard` CRD (`grafana.integreatly.org/v1beta1`)
reconciled by [grafana-operator]. Chart bumped **1.8.2 → 1.9.0**.

See [`CHANGELOG.md`](../blob/chart/grafana-dashboard-crd/CHANGELOG.md) →
`Chart / 1.9.0` for the full entry.

## Breaking changes

- `grafanaDashboard.label` **removed**. The sidecar discovery flow is no
  longer supported by this chart — install grafana-operator or pin the
  chart to `1.8.x`.
- `grafanaDashboard.instanceSelector.matchLabels` is now **required** when
  `grafanaDashboard.enabled=true`. The schema rejects empty / null values
  so the resulting CR cannot silently fail to bind to a `Grafana` instance.
- New knobs: `grafanaDashboard.instanceSelector`,
  `grafanaDashboard.allowCrossNamespaceImport`,
  `grafanaDashboard.folder`, `grafanaDashboard.resyncPeriod`.

## Release flow

Merge → tag `chart-v1.9.0` on `main` → CI publishes the OCI artifact at
`ghcr.io/intrinsec/s3proxy/charts/s3proxy:1.9.0` (see `ci(helm)` commit
`38907fb` for the trigger).

## Test plan

- [ ] `helm lint charts/s3proxy`
- [ ] Renders the CRD with default values:
  ```
  helm template t charts/s3proxy \
    --set grafanaDashboard.enabled=true \
    --set grafanaDashboard.folder=s3proxy \
    --show-only templates/grafana-dashboard.yaml
  ```
  Expect `apiVersion: grafana.integreatly.org/v1beta1`, `kind: GrafanaDashboard`,
  `spec.folder: s3proxy`, populated `spec.instanceSelector.matchLabels`.
- [ ] Negative — missing `matchLabels` must fail schema validation:
  ```
  helm template t charts/s3proxy \
    --set grafanaDashboard.enabled=true \
    --set grafanaDashboard.instanceSelector.matchLabels=null
  ```
  Expect exit ≠ 0 with a schema error on `grafanaDashboard.instanceSelector.matchLabels`.
- [ ] CI green on `chart/grafana-dashboard-crd`.

[grafana-operator]: https://grafana.github.io/grafana-operator/

🤖 Generated with [Claude Code](https://claude.com/claude-code)