### PR TITLE
fix(chart): make Grafana dashboard datasource portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Two version streams move independently:
 
 ### Chart
 
+- **`chart/1.9.1`** — Make the bundled Grafana dashboard portable. Adds a
+  `datasource` template variable (type `datasource`, query `prometheus`)
+  so the dashboard binds to whichever Prometheus data source the target
+  Grafana exposes instead of hard-coding `uid: prometheus`. The existing
+  `instance` variable and every panel target now reference
+  `${datasource}`. No values changes; upgrade is in-place.
 - **`chart/1.9.0`** — Replace the bundled Grafana dashboard `ConfigMap`
   with a `GrafanaDashboard` CRD (`grafana.integreatly.org/v1beta1`)
   reconciled by grafana-operator. New `grafanaDashboard.instanceSelector`,

--- a/charts/s3proxy/Chart.yaml
+++ b/charts/s3proxy/Chart.yaml
@@ -18,5 +18,5 @@ maintainers:
 annotations:
   org.opencontainers.image.source: "https://github.com/intrinsec/s3proxy/"
 type: application
-version: 1.9.0
+version: 1.9.1
 appVersion: "1.8.1"

--- a/charts/s3proxy/dashboards/s3proxy.json
+++ b/charts/s3proxy/dashboards/s3proxy.json
@@ -11,10 +11,18 @@
   "templating": {
     "list": [
       {
+        "name": "datasource",
+        "label": "Data source",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0
+      },
+      {
         "name": "instance",
         "label": "Instance",
         "type": "query",
-        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "query": "label_values(http_requests_total{service=\"s3proxy\"}, instance)",
         "includeAll": true,
         "multi": true,
@@ -30,6 +38,7 @@
       "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
       "targets": [
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "sum by (method, path) (rate(http_requests_total{service=\"s3proxy\", instance=~\"$instance\"}[1m]))",
           "legendFormat": "{{method}} {{path}}",
           "refId": "A"
@@ -44,6 +53,7 @@
       "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
       "targets": [
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "sum(rate(http_requests_total{service=\"s3proxy\", instance=~\"$instance\", status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_requests_total{service=\"s3proxy\", instance=~\"$instance\"}[5m])), 1e-12)",
           "legendFormat": "error ratio",
           "refId": "A"
@@ -58,16 +68,19 @@
       "gridPos": {"x": 0, "y": 8, "w": 12, "h": 8},
       "targets": [
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{service=\"s3proxy\", instance=~\"$instance\"}[5m])))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{service=\"s3proxy\", instance=~\"$instance\"}[5m])))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{service=\"s3proxy\", instance=~\"$instance\"}[5m])))",
           "legendFormat": "p99",
           "refId": "C"
@@ -82,6 +95,7 @@
       "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8},
       "targets": [
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "rate(service_crashes_total{service=\"s3proxy\", instance=~\"$instance\"}[5m])",
           "legendFormat": "crashes/s",
           "refId": "A"
@@ -96,11 +110,13 @@
       "gridPos": {"x": 0, "y": 16, "w": 12, "h": 8},
       "targets": [
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "histogram_quantile(0.95, sum by (le) (rate(s3proxy_encrypt_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
           "legendFormat": "encrypt p95",
           "refId": "A"
         },
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "histogram_quantile(0.95, sum by (le) (rate(s3proxy_decrypt_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
           "legendFormat": "decrypt p95",
           "refId": "B"
@@ -115,11 +131,13 @@
       "gridPos": {"x": 12, "y": 16, "w": 12, "h": 8},
       "targets": [
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "rate(s3proxy_throttled_total{instance=~\"$instance\"}[1m])",
           "legendFormat": "throttled/s",
           "refId": "A"
         },
         {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
           "expr": "rate(s3proxy_upstream_errors_total{instance=~\"$instance\"}[1m])",
           "legendFormat": "upstream errors/s",
           "refId": "B"


### PR DESCRIPTION
## Summary

The bundled Grafana dashboard hard-coded `datasource.uid: prometheus`, so
it only rendered on clusters whose Prometheus data source happened to be
named `prometheus`. This patch adds a `datasource` template variable
(type `datasource`, query `prometheus`) and rewrites every panel target
plus the existing `instance` query to reference `${datasource}`.

Chart bump **1.9.0 → 1.9.1**. No values changes; upgrade is in-place.

See `CHANGELOG.md` → `Chart / 1.9.1`.

## Test plan

- [ ] `helm lint charts/s3proxy`
- [ ] `jq empty charts/s3proxy/dashboards/s3proxy.json`
- [ ] Render emits `chart: s3proxy-1.9.1` and the new template var:
  ```
  helm template t charts/s3proxy \
    --set grafanaDashboard.enabled=true \
    --set grafanaDashboard.folder=s3proxy \
    --show-only templates/grafana-dashboard.yaml
  ```
  Expect a `templating.list` entry with `"name": "datasource"`,
  `"type": "datasource"`, `"query": "prometheus"`, and every panel
  target carrying `"datasource": {"type": "prometheus", "uid": "${datasource}"}`.
- [ ] Apply against a real `Grafana` instance whose Prometheus DS is *not*
  named `prometheus`; confirm the dashboard renders and the data source
  picker is populated.
- [ ] CI green on `chart/dashboard-datasource-var`.

## Release flow

Merge → tag `chart-v1.9.1` on `main` → CI publishes
`ghcr.io/intrinsec/s3proxy/charts/s3proxy:1.9.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)