### PR TITLE
fix(chart): dashboard filters on `job`, not the unset `service=s3proxy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Two version streams move independently:
 
 ### Chart
 
+- **`chart/1.9.2`** — Fix dashboard panels showing "No data". Every query
+  previously filtered on `service="s3proxy"`, but the
+  `ServiceMonitor`-applied label is the release-prefixed Service name
+  (e.g. `service="cockpit-s3proxy"`), so the filter never matched. Switch
+  every panel target and the `instance` variable query to `job=~"$job"`,
+  and add a new `Job` template variable (`label_values(http_requests_total, job)`)
+  so the dashboard picks up whatever `job` Prometheus actually emits.
 - **`chart/1.9.1`** — Make the bundled Grafana dashboard portable. Adds a
   `datasource` template variable (type `datasource`, query `prometheus`)
   so the dashboard binds to whichever Prometheus data source the target

--- a/charts/s3proxy/Chart.yaml
+++ b/charts/s3proxy/Chart.yaml
@@ -18,5 +18,5 @@ maintainers:
 annotations:
   org.opencontainers.image.source: "https://github.com/intrinsec/s3proxy/"
 type: application
-version: 1.9.1
+version: 1.9.2
 appVersion: "1.8.1"

--- a/charts/s3proxy/dashboards/s3proxy.json
+++ b/charts/s3proxy/dashboards/s3proxy.json
@@ -19,11 +19,21 @@
         "hide": 0
       },
       {
+        "name": "job",
+        "label": "Job",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "${datasource}"},
+        "query": "label_values(http_requests_total, job)",
+        "includeAll": false,
+        "multi": false,
+        "refresh": 2
+      },
+      {
         "name": "instance",
         "label": "Instance",
         "type": "query",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
-        "query": "label_values(http_requests_total{service=\"s3proxy\"}, instance)",
+        "query": "label_values(http_requests_total{job=~\"$job\"}, instance)",
         "includeAll": true,
         "multi": true,
         "refresh": 2
@@ -39,7 +49,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "sum by (method, path) (rate(http_requests_total{service=\"s3proxy\", instance=~\"$instance\"}[1m]))",
+          "expr": "sum by (method, path) (rate(http_requests_total{job=~\"$job\", instance=~\"$instance\"}[1m]))",
           "legendFormat": "{{method}} {{path}}",
           "refId": "A"
         }
@@ -54,7 +64,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "sum(rate(http_requests_total{service=\"s3proxy\", instance=~\"$instance\", status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_requests_total{service=\"s3proxy\", instance=~\"$instance\"}[5m])), 1e-12)",
+          "expr": "sum(rate(http_requests_total{job=~\"$job\", instance=~\"$instance\", status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_requests_total{job=~\"$job\", instance=~\"$instance\"}[5m])), 1e-12)",
           "legendFormat": "error ratio",
           "refId": "A"
         }
@@ -69,19 +79,19 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{service=\"s3proxy\", instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[5m])))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{service=\"s3proxy\", instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[5m])))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{service=\"s3proxy\", instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[5m])))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -96,7 +106,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "rate(service_crashes_total{service=\"s3proxy\", instance=~\"$instance\"}[5m])",
+          "expr": "rate(service_crashes_total{job=~\"$job\", instance=~\"$instance\"}[5m])",
           "legendFormat": "crashes/s",
           "refId": "A"
         }
@@ -111,13 +121,13 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(s3proxy_encrypt_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(s3proxy_encrypt_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[5m])))",
           "legendFormat": "encrypt p95",
           "refId": "A"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(s3proxy_decrypt_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(s3proxy_decrypt_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[5m])))",
           "legendFormat": "decrypt p95",
           "refId": "B"
         }
@@ -132,13 +142,13 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "rate(s3proxy_throttled_total{instance=~\"$instance\"}[1m])",
+          "expr": "rate(s3proxy_throttled_total{job=~\"$job\", instance=~\"$instance\"}[1m])",
           "legendFormat": "throttled/s",
           "refId": "A"
         },
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "rate(s3proxy_upstream_errors_total{instance=~\"$instance\"}[1m])",
+          "expr": "rate(s3proxy_upstream_errors_total{job=~\"$job\", instance=~\"$instance\"}[1m])",
           "legendFormat": "upstream errors/s",
           "refId": "B"
         }


### PR DESCRIPTION
## Summary

Every dashboard panel filtered on `service="s3proxy"`, but the
`ServiceMonitor`-applied `service` label is the release-prefixed Service
name (e.g. `service="cockpit-s3proxy"`), so the filter never matched and
panels rendered **"No data"**. `job` carries the same release-prefixed
value but is the label Prometheus actually exposes consistently.

This patch:

- Adds a `job` template variable (`label_values(http_requests_total, job)`)
  between the existing `datasource` and `instance` variables, so the
  dashboard picks up whatever job string Prometheus emits.
- Replaces `service="s3proxy"` with `job=~"$job"` in every panel target
  and in the `instance` variable's `query`.
- Adds the same `job=~"$job"` filter to the `s3proxy_*` panels (panels 5
  and 6) so they also scope correctly in multi-release clusters.

Chart bump **1.9.1 → 1.9.2**. No values changes.

See `CHANGELOG.md` → `Chart / 1.9.2`.

## Test plan

- [x] `jq . charts/s3proxy/dashboards/s3proxy.json >/dev/null` — valid JSON
- [x] `helm lint charts/s3proxy` — passes
- [x] `helm template t charts/s3proxy --set grafanaDashboard.enabled=true --show-only templates/grafana-dashboard.yaml | grep -cF 'job=~\"$job\"'` → **11** (≥ 11)
- [x] Same render: `grep -cF 'service=\"s3proxy\"'` → **0** (no stale filter)
- [ ] Apply against the cluster that triggered the bug; confirm panels
  populate and the `Job` picker lists e.g. `cockpit-s3proxy`.
- [ ] CI green on `chart/dashboard-job-variable`.

## Release flow

Merge → tag `chart-v1.9.2` on `main` → CI publishes
`ghcr.io/intrinsec/s3proxy/charts/s3proxy:1.9.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)