### PR TITLE
feat(chart): dashboard `Job` picker defaults to All + Go runtime panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ Two version streams move independently:
 
 ### Chart
 
+- **`chart/1.9.3`** — Dashboard usability + Go runtime panels.
+  - `Job` picker now defaults to **All** (`allValue: ".*s3proxy.*"`) and
+    restricts its dropdown to jobs whose name contains `s3proxy` via the
+    template `regex: /s3proxy/`. Multi-release clusters land on a
+    populated dashboard out of the box.
+  - New **Runtime (Go)** row with six panels backed by the default
+    `client_golang` collectors (already registered in s3proxy):
+    CPU usage (`process_cpu_seconds_total`), resident memory
+    (`process_resident_memory_bytes`), Go heap in use
+    (`go_memstats_heap_inuse_bytes` / `_heap_alloc_bytes`), goroutines
+    (`go_goroutines`), GC pause quantiles (`go_gc_duration_seconds`),
+    and open file descriptors (`process_open_fds`).
 - **`chart/1.9.2`** — Fix dashboard panels showing "No data". Every query
   previously filtered on `service="s3proxy"`, but the
   `ServiceMonitor`-applied label is the release-prefixed Service name

--- a/charts/s3proxy/Chart.yaml
+++ b/charts/s3proxy/Chart.yaml
@@ -18,5 +18,5 @@ maintainers:
 annotations:
   org.opencontainers.image.source: "https://github.com/intrinsec/s3proxy/"
 type: application
-version: 1.9.2
+version: 1.9.3
 appVersion: "1.8.1"

--- a/charts/s3proxy/dashboards/s3proxy.json
+++ b/charts/s3proxy/dashboards/s3proxy.json
@@ -24,7 +24,10 @@
         "type": "query",
         "datasource": {"type": "prometheus", "uid": "${datasource}"},
         "query": "label_values(http_requests_total, job)",
-        "includeAll": false,
+        "regex": "/s3proxy/",
+        "includeAll": true,
+        "allValue": ".*s3proxy.*",
+        "current": {"text": "All", "value": "$__all"},
         "multi": false,
         "refresh": 2
       },
@@ -154,6 +157,122 @@
         }
       ],
       "fieldConfig": {"defaults": {"unit": "ops"}}
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "Runtime (Go)",
+      "collapsed": false,
+      "gridPos": {"x": 0, "y": 24, "w": 24, "h": 1},
+      "panels": []
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "CPU usage (cores)",
+      "gridPos": {"x": 0, "y": 25, "w": 12, "h": 8},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "rate(process_cpu_seconds_total{job=~\"$job\", instance=~\"$instance\"}[2m])",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "none", "min": 0}}
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Resident memory (RSS)",
+      "gridPos": {"x": 12, "y": 25, "w": 12, "h": 8},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "process_resident_memory_bytes{job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "bytes", "min": 0}}
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Go heap in use",
+      "gridPos": {"x": 0, "y": 33, "w": 12, "h": 8},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "heap inuse {{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "heap alloc {{instance}}",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "bytes", "min": 0}}
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Goroutines",
+      "gridPos": {"x": 12, "y": 33, "w": 12, "h": 8},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "go_goroutines{job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0}}
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "GC pause (p50 / p95 / p99)",
+      "gridPos": {"x": 0, "y": 41, "w": 12, "h": 8},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "go_gc_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.5\"}",
+          "legendFormat": "p50 {{instance}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "go_gc_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.95\"}",
+          "legendFormat": "p95 {{instance}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "go_gc_duration_seconds{job=~\"$job\", instance=~\"$instance\", quantile=\"0.99\"}",
+          "legendFormat": "p99 {{instance}}",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "s", "min": 0}}
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Open file descriptors",
+      "gridPos": {"x": 12, "y": 41, "w": 12, "h": 8},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "process_open_fds{job=~\"$job\", instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "short", "min": 0}}
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two related dashboard improvements, packaged as a single chart bump
**1.9.2 → 1.9.3**.

### 1. `Job` picker now defaults to All

The `Job` template variable previously had no default, so opening the
dashboard could show "No data" until a user manually picked a job. Now:

- `includeAll: true`
- `allValue: ".*s3proxy.*"`
- `current: { text: "All", value: "$__all" }`
- Template `regex: /s3proxy/` restricts the dropdown to jobs whose name
  contains `s3proxy`.

Effect: dashboard opens populated on multi-release clusters; the
dropdown only lists relevant jobs.

### 2. New **Runtime (Go)** row

Six panels backed by the default `client_golang` collectors that
s3proxy already registers (`collectors.NewGoCollector` +
`NewProcessCollector` in `s3proxy/internal/monitoring/monitoring.go`):

| Panel | Metric |
| --- | --- |
| CPU usage (cores) | `rate(process_cpu_seconds_total[2m])` |
| Resident memory (RSS) | `process_resident_memory_bytes` |
| Go heap in use | `go_memstats_heap_inuse_bytes`, `_heap_alloc_bytes` |
| Goroutines | `go_goroutines` |
| GC pause (p50/p95/p99) | `go_gc_duration_seconds{quantile=…}` |
| Open file descriptors | `process_open_fds` |

All scoped on `job=~"$job", instance=~"$instance"` so the existing
pickers apply. No app code change — these metrics already ship.

See `CHANGELOG.md` → `Chart / 1.9.3`.

## Test plan

- [x] `jq . charts/s3proxy/dashboards/s3proxy.json >/dev/null` — valid JSON
- [x] `helm lint charts/s3proxy` — passes
- [x] Render hits the new defaults exactly once:
  ```
  helm template t charts/s3proxy --set grafanaDashboard.enabled=true \
    --show-only templates/grafana-dashboard.yaml \
    | grep -E '"allValue": "\.\*s3proxy\.\*"'
  ```
  → 1
- [x] Render exposes all six new runtime metric names (8 matches across
  panel targets).
- [x] Render keeps `job=~"$job"` filtering everywhere (20 hits) and has
  zero stale `service="s3proxy"` filters.
- [ ] Open the dashboard on the bug-reporting cluster; confirm panels
  populate without touching the picker and the Runtime row renders.
- [ ] CI green on `chart/dashboard-job-default-allmatch`.

## Release flow

Merge → tag `chart-v1.9.3` on `main` → CI publishes
`ghcr.io/intrinsec/s3proxy/charts/s3proxy:1.9.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)