### PR TITLE
feat(chart): add deploymentAnnotations for Deployment metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@ Two version streams move independently:
 
 ### Chart
 
-- **`chart/1.9.3`** — Dashboard usability + Go runtime panels.
+- **`chart/1.10.0`** — New `deploymentAnnotations` value, rendered onto the
+  `Deployment` object's own `metadata.annotations`. Until now the chart only
+  exposed `podAnnotations`, which lands on the pod template — so controllers
+  that watch the workload metadata had no way in. The motivating case is
+  Stakater Reloader (`reloader.stakater.com/auto: "true"`): the TLS secret is
+  mounted with `subPath`, which kubelet never refreshes in place, so a renewed
+  certificate is only picked up when the pods restart. Without the annotation
+  the proxy keeps serving the expired certificate after cert-manager rotates
+  it, and every TLS client fails with `x509: certificate has expired`.
   - `Job` picker now defaults to **All** (`allValue: ".*s3proxy.*"`) and
     restricts its dropdown to jobs whose name contains `s3proxy` via the
     template `regex: /s3proxy/`. Multi-release clusters land on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Two version streams move independently:
   certificate is only picked up when the pods restart. Without the annotation
   the proxy keeps serving the expired certificate after cert-manager rotates
   it, and every TLS client fails with `x509: certificate has expired`.
+- **`chart/1.9.3`** — Dashboard usability + Go runtime panels.
   - `Job` picker now defaults to **All** (`allValue: ".*s3proxy.*"`) and
     restricts its dropdown to jobs whose name contains `s3proxy` via the
     template `regex: /s3proxy/`. Multi-release clusters land on a

--- a/charts/s3proxy/Chart.yaml
+++ b/charts/s3proxy/Chart.yaml
@@ -18,5 +18,5 @@ maintainers:
 annotations:
   org.opencontainers.image.source: "https://github.com/intrinsec/s3proxy/"
 type: application
-version: 1.9.3
+version: 1.10.0
 appVersion: "1.8.1"

--- a/charts/s3proxy/templates/deployment.yaml
+++ b/charts/s3proxy/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "s3proxy.fullname" . }}
   labels:
     {{- include "s3proxy.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/s3proxy/values.schema.json
+++ b/charts/s3proxy/values.schema.json
@@ -99,6 +99,7 @@
       "type": "object",
       "additionalProperties": true
     },
+    "deploymentAnnotations": { "type": "object" },
     "podAnnotations": { "type": "object" },
     "podLabels": { "type": "object" },
     "podSecurityContext": { "type": "object" },

--- a/charts/s3proxy/values.yaml
+++ b/charts/s3proxy/values.yaml
@@ -80,6 +80,15 @@ valsSecret: {}
 #   secretKey: ref+vault://s3proxy/secrets/secret-key
 #   encryptKey: ref+vault://s3proxy/secrets/encrypt-key
 
+# Annotations set on the Deployment object itself (not the pod template).
+# Required by controllers that watch the workload metadata, e.g. Stakater
+# Reloader, which restarts the pods when the TLS secret is renewed:
+#   deploymentAnnotations:
+#     reloader.stakater.com/auto: "true"
+# The cert secret is mounted with subPath, so kubelet never refreshes it
+# in-place — a pod restart is the only way to pick up a renewed certificate.
+deploymentAnnotations: {}
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
## Context

Found while investigating a production incident on kube02: every Loki read
query failed with

```
tls: failed to verify certificate: x509: certificate has expired or is not yet
valid: current time 2026-07-29T12:18:00Z is after 2026-07-26T16:05:14Z
```

against `cockpit-s3proxy.cockpit.svc.cluster.local:4433`.

cert-manager had renewed the certificate correctly — the secret held a cert
valid until 2026-09-24 — but the running pods were still serving the previous
one, issued in April and expired on July 26. The pods had started on
2026-06-25, hours before the renewal, and never picked up the new material.

Two things combined:

1. The cert secret is mounted with `subPath`. Kubelet never refreshes a
   subPath volume in place, so the file inside the container stays frozen at
   whatever the secret held when the pod started. A pod restart is the only
   way to pick up a renewed certificate.
2. The chart exposes `podAnnotations` only, which renders onto the pod
   template. Stakater Reloader reads `reloader.stakater.com/auto` from
   `Deployment.metadata.annotations`, so there was no way to opt the workload
   into automatic restarts through values.

The consuming chart had already set `s3proxy.annotations.reloader.stakater.com/auto: "true"`
in its values, assuming it would land on the Deployment. No template consumed
that key, so it was silently dropped and the rotation went unnoticed until the
old certificate expired a month later.

## Change

Add a `deploymentAnnotations` value (default `{}`, declared in
`values.schema.json`) rendered onto the Deployment's own
`metadata.annotations`:

```yaml
deploymentAnnotations:
  reloader.stakater.com/auto: "true"
```

Chart bumped 1.9.3 → 1.10.0. No behavior change when the value is unset.

## Verification

- `helm lint` — passes.
- `helm template` without the value — Deployment metadata carries no
  `annotations` block, byte-identical to 1.9.3.
- `helm template` with the value — annotation renders on the Deployment
  metadata, correctly quoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)