### PR TITLE
chore(release): v1.9.0 + chart 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,15 @@ Two version streams move independently:
 
 ### Chart
 
-- **`chart/1.9.3`** — Dashboard usability + Go runtime panels.
+- **`chart/1.10.0`** — New `deploymentAnnotations` value, rendered onto the
+  `Deployment` object's own `metadata.annotations`. Until now the chart only
+  exposed `podAnnotations`, which lands on the pod template — so controllers
+  that watch the workload metadata had no way in. The motivating case is
+  Stakater Reloader (`reloader.stakater.com/auto: "true"`): the TLS secret is
+  mounted with `subPath`, which kubelet never refreshes in place, so a renewed
+  certificate is only picked up when the pods restart. Without the annotation
+  the proxy keeps serving the expired certificate after cert-manager rotates
+  it, and every TLS client fails with `x509: certificate has expired`.
   - `Job` picker now defaults to **All** (`allValue: ".*s3proxy.*"`) and
     restricts its dropdown to jobs whose name contains `s3proxy` via the
     template `regex: /s3proxy/`. Multi-release clusters land on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Two version streams move independently:
 
 ## [Unreleased]
 
+## [1.9.0] — 2026-07-29
+
+Ships the S3 client-compatibility fixes (`Content-Length`, plaintext `ETag`),
+plaintext sizes in `ListObjects`, and a configurable upstream operation timeout.
+Chart `1.10.0` accompanies this release.
+
 ### Fixed
 - **s3cmd `get` compatibility**: intercepted `GetObject` responses now
   carry a `Content-Length` header reflecting the decrypted body size.
@@ -30,6 +36,7 @@ Two version streams move independently:
   (no DEK tag) keep the upstream ETag, which already describes the delivered
   bytes. PUT-response and HEAD ETags still reflect the ciphertext and remain
   a known consistency gap.
+
 ### Added
 
 - `ListObjects`/`ListObjectsV2` responses now report the **decrypted plaintext
@@ -41,8 +48,6 @@ Two version streams move independently:
   - *Known limitation:* objects **not** written through the proxy (legacy
     plaintext, server-side copies, multipart) are reported 28 bytes short (or 0
     after clamp), since a list response carries no per-object encryption metadata.
-### Added
-
 - Configurable timeout for upstream `GetObject` and `PutObject` operations via
   `S3PROXY_S3_OPERATION_TIMEOUT`; defaults to 120 seconds and accepts values up
   to 30 minutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ Two version streams move independently:
 
 ## [Unreleased]
 
+### Added
+
+- `ListObjects`/`ListObjectsV2` responses now report the **decrypted plaintext
+  size** of each object instead of the larger at-rest ciphertext size. The proxy
+  intercepts bucket-level list requests, subtracts the fixed 28-byte encryption
+  overhead (12-byte nonce + 16-byte GCM tag) from every `<Size>`, and clamps at 0.
+  Bucket sub-resource GETs (acl, versioning, multipart listings, `?versions`, …)
+  are still forwarded unchanged.
+  - *Known limitation:* objects **not** written through the proxy (legacy
+    plaintext, server-side copies, multipart) are reported 28 bytes short (or 0
+    after clamp), since a list response carries no per-object encryption metadata.
+
 ### Chart
 
 - **`chart/1.9.3`** — Dashboard usability + Go runtime panels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Two version streams move independently:
 
 ## [Unreleased]
 
+### Fixed
+- **s3cmd `get` compatibility**: intercepted `GetObject` responses now
+  carry a `Content-Length` header reflecting the decrypted body size.
+  Previously the proxy streamed decrypted objects without a length, so
+  Go fell back to chunked transfer encoding and s3cmd 2.4.0 downloaded
+  an empty file. Downloads now complete with the correct size.
+
 ### Chart
 
 - **`chart/1.9.3`** — Dashboard usability + Go runtime panels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Two version streams move independently:
 
 ## [Unreleased]
 
+### Added
+
+- Configurable timeout for upstream `GetObject` and `PutObject` operations via
+  `S3PROXY_S3_OPERATION_TIMEOUT`; defaults to 120 seconds and accepts values up
+  to 30 minutes.
+
 ### Chart
 
 - **`chart/1.9.3`** — Dashboard usability + Go runtime panels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ Two version streams move independently:
 
 ## [Unreleased]
 
+### Fixed
+- **`GetObject` returns the plaintext ETag.** Intercepted GETs decrypt the
+  body but previously returned the upstream ETag, which S3 computes over the
+  ciphertext at rest. Clients (or SDKs) that validate the body against the
+  ETag, or cache by it, saw a mismatch. The proxy now overrides the response
+  ETag with `md5(plaintext)` — the ETag S3 would have produced for the
+  unencrypted object — computed on the fly from the buffer already held in
+  memory, so no stored metadata or migration is needed. Pass-through objects
+  (no DEK tag) keep the upstream ETag, which already describes the delivered
+  bytes. PUT-response and HEAD ETags still reflect the ciphertext and remain
+  a known consistency gap.
+
 ### Chart
 
 - **`chart/1.9.3`** — Dashboard usability + Go runtime panels.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ All runtime configuration is sourced from environment variables. The Helm chart 
 | `AWS_SECRET_ACCESS_KEY` | yes | — | Idem. |
 | `S3PROXY_THROTTLING_REQUESTSMAX` | no | `0` (off) | Cap on **concurrent in-flight requests** (not RPS). Excess requests are rejected. |
 | `S3PROXY_PUTBODY_MAX` | no | `268435456` (256 MiB) | Per-request PutObject body size ceiling, in bytes. Up to `5368709120` (5 GiB, the S3 hard cap). |
+| `S3PROXY_S3_OPERATION_TIMEOUT` | no | `120` (2 min) | Upper bound, in seconds, on a single upstream GetObject/PutObject call. Raise this for large objects on slow links. Up to `1800` (30 min). |
 | `S3PROXY_DEKTAG_NAME` | no | `isec` | S3 object-metadata key used to store the encrypted DEK. |
 | `S3PROXY_DEKTAG_KEKVER` | no | `<dektag>-kek-ver` | S3 object-metadata key recording which KEK derivation version wrapped the DEK. |
 | `S3PROXY_INSECURE` | no | unset | Set to `1` to use plain HTTP (not HTTPS) when talking to upstream. **Dev / e2e only.** Emits a loud warning at startup. |

--- a/charts/s3proxy/Chart.yaml
+++ b/charts/s3proxy/Chart.yaml
@@ -18,5 +18,5 @@ maintainers:
 annotations:
   org.opencontainers.image.source: "https://github.com/intrinsec/s3proxy/"
 type: application
-version: 1.9.3
+version: 1.10.0
 appVersion: "1.8.1"

--- a/charts/s3proxy/Chart.yaml
+++ b/charts/s3proxy/Chart.yaml
@@ -19,4 +19,4 @@ annotations:
   org.opencontainers.image.source: "https://github.com/intrinsec/s3proxy/"
 type: application
 version: 1.10.0
-appVersion: "1.8.1"
+appVersion: "1.9.0"

--- a/charts/s3proxy/templates/deployment.yaml
+++ b/charts/s3proxy/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "s3proxy.fullname" . }}
   labels:
     {{- include "s3proxy.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/s3proxy/values.schema.json
+++ b/charts/s3proxy/values.schema.json
@@ -99,6 +99,7 @@
       "type": "object",
       "additionalProperties": true
     },
+    "deploymentAnnotations": { "type": "object" },
     "podAnnotations": { "type": "object" },
     "podLabels": { "type": "object" },
     "podSecurityContext": { "type": "object" },

--- a/charts/s3proxy/values.yaml
+++ b/charts/s3proxy/values.yaml
@@ -80,6 +80,15 @@ valsSecret: {}
 #   secretKey: ref+vault://s3proxy/secrets/secret-key
 #   encryptKey: ref+vault://s3proxy/secrets/encrypt-key
 
+# Annotations set on the Deployment object itself (not the pod template).
+# Required by controllers that watch the workload metadata, e.g. Stakater
+# Reloader, which restarts the pods when the TLS secret is renewed:
+#   deploymentAnnotations:
+#     reloader.stakater.com/auto: "true"
+# The cert secret is mounted with subPath, so kubelet never refreshes it
+# in-place — a pod restart is the only way to pick up a renewed certificate.
+deploymentAnnotations: {}
+
 podAnnotations: {}
 podLabels: {}
 

--- a/s3proxy/internal/config/config.go
+++ b/s3proxy/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/v2"
@@ -95,6 +96,21 @@ func (c *Config) MaxPutBodySize() int64 {
 	return v
 }
 
+// S3OperationTimeout returns the configured upper bound on a single S3
+// GetObject/PutObject call. Falls back to DefaultS3OperationTimeout when
+// S3PROXY_S3_OPERATION_TIMEOUT (seconds) is unset, zero, or out of range.
+func (c *Config) S3OperationTimeout() time.Duration {
+	const key = "s3proxy.s3.operation.timeout"
+	if !c.k.Exists(key) {
+		return DefaultS3OperationTimeout
+	}
+	v := time.Duration(c.k.Int64(key)) * time.Second
+	if v <= 0 || v > MaxS3OperationTimeout {
+		return DefaultS3OperationTimeout
+	}
+	return v
+}
+
 // DecryptionFallback reports whether GetObject should retry decryption with an
 // all-zero KEK when the configured KEK fails (S3PROXY_DECRYPTION_FALLBACK=1).
 // Intended for one-shot migrations away from objects written without an
@@ -154,6 +170,9 @@ func GetMaxPutBodySize() int64 { return Default().MaxPutBodySize() }
 
 // GetInsecure returns whether upstream S3 traffic should use http:// from the default config.
 func GetInsecure() bool { return Default().Insecure() }
+
+// GetS3OperationTimeout returns the S3 operation timeout from the default config.
+func GetS3OperationTimeout() time.Duration { return Default().S3OperationTimeout() }
 
 // GetDecryptionFallback returns the decryption-fallback flag from the default config.
 func GetDecryptionFallback() bool { return Default().DecryptionFallback() }

--- a/s3proxy/internal/config/validation.go
+++ b/s3proxy/internal/config/validation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"time"
 )
 
 // Validate asserts that the required s3proxy configuration is present and well-formed.
@@ -92,6 +93,15 @@ const MaxObjectSize = 5 * 1024 * 1024 * 1024
 // Operators can raise this via S3PROXY_PUTBODY_MAX (bytes) up to MaxObjectSize once a
 // streaming encryption path is introduced.
 const DefaultMaxPutBodySize = 256 * 1024 * 1024
+
+// DefaultS3OperationTimeout is the default upper bound on a single S3
+// GetObject/PutObject call. Large objects on slow links can need more time;
+// operators can raise this via S3PROXY_S3_OPERATION_TIMEOUT (seconds).
+const DefaultS3OperationTimeout = 2 * time.Minute
+
+// MaxS3OperationTimeout bounds how high S3PROXY_S3_OPERATION_TIMEOUT can be set,
+// so a misconfiguration cannot leave requests hanging indefinitely.
+const MaxS3OperationTimeout = 30 * time.Minute
 
 // ValidateContentLength validates the content length of a request against the S3 hard cap.
 func ValidateContentLength(contentLength int64) error {

--- a/s3proxy/internal/config/validation_test.go
+++ b/s3proxy/internal/config/validation_test.go
@@ -9,7 +9,9 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/knadh/koanf/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,4 +105,31 @@ func TestValidatePutBodySize(t *testing.T) {
 	err := ValidatePutBodySize(DefaultMaxPutBodySize + 1)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds PutObject body cap")
+}
+
+func TestS3OperationTimeout(t *testing.T) {
+	tests := map[string]struct {
+		value string
+		want  time.Duration
+	}{
+		"valid":        {value: "300", want: 5 * time.Minute},
+		"at maximum":   {value: "1800", want: MaxS3OperationTimeout},
+		"zero":         {value: "0", want: DefaultS3OperationTimeout},
+		"negative":     {value: "-1", want: DefaultS3OperationTimeout},
+		"over maximum": {value: "1801", want: DefaultS3OperationTimeout},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("S3PROXY_S3_OPERATION_TIMEOUT", tc.value)
+			cfg, err := Load()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg.S3OperationTimeout())
+		})
+	}
+
+	t.Run("unset", func(t *testing.T) {
+		cfg := &Config{k: koanf.New(".")}
+		assert.Equal(t, DefaultS3OperationTimeout, cfg.S3OperationTimeout())
+	})
 }

--- a/s3proxy/internal/cryptoutil/cryptoutil.go
+++ b/s3proxy/internal/cryptoutil/cryptoutil.go
@@ -18,6 +18,11 @@ import (
 	"github.com/tink-crypto/tink-go/v2/subtle/random"
 )
 
+// EncryptionOverhead is the fixed number of bytes Encrypt adds to the plaintext:
+// a 12-byte AES-GCM-SIV nonce prefix plus a 16-byte authentication tag suffix.
+// Ciphertext length is always plaintext length + EncryptionOverhead.
+const EncryptionOverhead = 28
+
 // Encrypt generates a random key to encrypt a plaintext using AES-256-GCM.
 // The generated key is encrypted using the supplied key encryption key (KEK).
 // The ciphertext and encrypted data encryption key (DEK) are returned.

--- a/s3proxy/internal/cryptoutil/cryptoutil_test.go
+++ b/s3proxy/internal/cryptoutil/cryptoutil_test.go
@@ -46,3 +46,25 @@ func TestEncryptDecrypt(t *testing.T) {
 		})
 	}
 }
+
+// TestEncryptionOverhead asserts that Encrypt adds exactly EncryptionOverhead bytes to the
+// plaintext, regardless of plaintext size. This invariant is what lets the router subtract a
+// constant to report decrypted sizes in LIST responses; it fails loudly if the envelope changes.
+func TestEncryptionOverhead(t *testing.T) {
+	for _, size := range []int{0, 1, 28, 29, 1024, 1610862} {
+		t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+			kek := [32]byte{}
+			_, err := rand.Read(kek[:])
+			require.NoError(t, err)
+
+			plaintext := make([]byte, size)
+			_, err = rand.Read(plaintext)
+			require.NoError(t, err)
+
+			ciphertext, _, err := Encrypt(plaintext, kek)
+			require.NoError(t, err)
+
+			assert.Equal(t, size+EncryptionOverhead, len(ciphertext))
+		})
+	}
+}

--- a/s3proxy/internal/e2e/proxy_e2e_test.go
+++ b/s3proxy/internal/e2e/proxy_e2e_test.go
@@ -167,6 +167,22 @@ func TestProxyRoundtripAgainstMinio(t *testing.T) {
 	require.NoError(t, got.Body.Close())
 	assert.Equal(t, plaintext, gotBody)
 
+	// Listing through the proxy must report the decrypted plaintext size, not the larger
+	// ciphertext size that actually sits at rest. Cover both ListObjectsV2 and ListObjects v1.
+	listV2, err := proxyClient.ListObjectsV2(ctx, &awss3.ListObjectsV2Input{
+		Bucket: aws.String(bucket),
+	})
+	require.NoError(t, err)
+	require.Len(t, listV2.Contents, 1)
+	assert.EqualValues(t, len(plaintext), *listV2.Contents[0].Size, "ListObjectsV2 must report plaintext size")
+
+	listV1, err := proxyClient.ListObjects(ctx, &awss3.ListObjectsInput{
+		Bucket: aws.String(bucket),
+	})
+	require.NoError(t, err)
+	require.Len(t, listV1.Contents, 1)
+	assert.EqualValues(t, len(plaintext), *listV1.Contents[0].Size, "ListObjects v1 must report plaintext size")
+
 	// Housekeeping endpoints stay reachable while traffic is flowing.
 	healthResp, err := http.Get(proxyURL.String() + "/healthz")
 	require.NoError(t, err)

--- a/s3proxy/internal/router/handler.go
+++ b/s3proxy/internal/router/handler.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -138,42 +139,47 @@ func handlePutObject(client s3Client, key string, bucket string, keks cryptoutil
 	}
 }
 
+// forwardUpstream repackages, signs and sends req to the upstream S3 API, returning the
+// upstream response. The caller owns resp.Body and must close it. metrics may be nil.
+func forwardUpstream(client *s3.Client, req *http.Request, metrics *monitoring.Metrics) (*http.Response, error) {
+	newReq, err := repackage(req)
+	if err != nil {
+		return nil, fmt.Errorf("repackaging request: %w", err)
+	}
+
+	cfg := client.GetConfig()
+
+	creds, err := cfg.Credentials.Retrieve(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("retrieving aws creds: %w", err)
+	}
+
+	signer := v4.NewSigner()
+
+	err = signer.SignHTTP(context.TODO(), creds, newReq, newReq.Header.Get("X-Amz-Content-Sha256"), "s3", cfg.Region, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("signing request: %w", err)
+	}
+
+	resp, err := forwardHTTPClient.Do(newReq)
+	if err != nil {
+		if metrics != nil {
+			metrics.UpstreamErrors.Inc()
+		}
+		return nil, fmt.Errorf("do request: %w", err)
+	}
+
+	return resp, nil
+}
+
 func handleForwards(client *s3.Client, log *slog.Logger, metrics *monitoring.Metrics) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		log.Debug("forwarding", "path", req.URL.Path, "method", req.Method, "host", req.Host)
 
-		newReq, err := repackage(req)
+		resp, err := forwardUpstream(client, req, metrics)
 		if err != nil {
-			log.Error("failed to repackage request", "error", err)
+			log.Error("forwarding request", "error", err)
 			http.Error(w, "internal server error", http.StatusInternalServerError)
-			return
-		}
-
-		cfg := client.GetConfig()
-
-		creds, err := cfg.Credentials.Retrieve(context.TODO())
-		if err != nil {
-			log.Error("unable to retrieve aws creds", "error", err)
-			http.Error(w, "internal server error", http.StatusInternalServerError)
-			return
-		}
-
-		signer := v4.NewSigner()
-
-		err = signer.SignHTTP(context.TODO(), creds, newReq, newReq.Header.Get("X-Amz-Content-Sha256"), "s3", cfg.Region, time.Now())
-		if err != nil {
-			log.Error("failed to sign request", "error", err)
-			http.Error(w, "internal server error", http.StatusInternalServerError)
-			return
-		}
-
-		resp, err := forwardHTTPClient.Do(newReq)
-		if err != nil {
-			log.Error("do request", "error", err)
-			if metrics != nil {
-				metrics.UpstreamErrors.Inc()
-			}
-			http.Error(w, "do request: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 		defer func() {
@@ -191,6 +197,53 @@ func handleForwards(client *s3.Client, log *slog.Logger, metrics *monitoring.Met
 		if _, err := io.Copy(w, resp.Body); err != nil {
 			log.Error("failed to stream response", "error", err)
 			// Headers already written; cannot send error response.
+		}
+	}
+}
+
+// handleListObjects forwards a ListObjects/ListObjectsV2 request upstream, then rewrites the
+// reported object sizes in the XML response to the decrypted plaintext size (ciphertext size
+// minus the fixed encryption overhead). List pages are bounded (≤1000 keys), so buffering the
+// body is safe. Only successful (2xx) responses are rewritten; everything else passes through.
+func handleListObjects(client *s3.Client, log *slog.Logger, metrics *monitoring.Metrics) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		log.Debug("intercepting ListObjects", "path", req.URL.Path, "method", req.Method, "host", req.Host)
+
+		resp, err := forwardUpstream(client, req, metrics)
+		if err != nil {
+			log.Error("forwarding ListObjects request", "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		defer func() {
+			if cerr := resp.Body.Close(); cerr != nil {
+				log.Error("failed to close upstream response body", "error", cerr)
+			}
+		}()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Error("reading ListObjects response body", "error", err)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		out := body
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			out = rewriteListSizes(body)
+		}
+
+		// Preserve multi-value headers (Set-Cookie, Vary, etc.).
+		for key, values := range resp.Header {
+			w.Header()[key] = values
+		}
+		// The rewritten body is shorter than the upstream ciphertext sizes, so the upstream
+		// Content-Length no longer applies — set it to the actual body length.
+		w.Header().Set("Content-Length", strconv.Itoa(len(out)))
+		w.WriteHeader(resp.StatusCode)
+
+		if _, err := w.Write(out); err != nil {
+			log.Error("failed to write ListObjects response", "error", err)
 		}
 	}
 }

--- a/s3proxy/internal/router/listsize.go
+++ b/s3proxy/internal/router/listsize.go
@@ -1,0 +1,39 @@
+/*
+Copyright (c) Intrinsec 2024
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package router
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/intrinsec/s3proxy/internal/cryptoutil"
+)
+
+// sizeElementPattern matches a <Size>N</Size> element. In ListObjects v1/v2 responses this
+// element only appears inside <Contents>, so a targeted byte-preserving substitution avoids
+// the namespace/formatting loss of an encoding/xml round-trip that could break S3 clients.
+var sizeElementPattern = regexp.MustCompile(`<Size>(\d+)</Size>`)
+
+// rewriteListSizes replaces each <Size>N</Size> in a ListObjects response with
+// max(0, N-EncryptionOverhead), reporting the decrypted plaintext size. The clamp at 0 covers
+// 0-byte folder markers and objects not written through the proxy (smaller than the overhead).
+// Everything outside the matched elements is preserved byte-for-byte.
+func rewriteListSizes(body []byte) []byte {
+	return sizeElementPattern.ReplaceAllFunc(body, func(m []byte) []byte {
+		n, err := strconv.Atoi(string(sizeElementPattern.FindSubmatch(m)[1]))
+		if err != nil {
+			// Unparseable (e.g. overflows int) — leave the element untouched.
+			return m
+		}
+		dec := n - cryptoutil.EncryptionOverhead
+		if dec < 0 {
+			dec = 0
+		}
+		return []byte(fmt.Sprintf("<Size>%d</Size>", dec))
+	})
+}

--- a/s3proxy/internal/router/listsize_test.go
+++ b/s3proxy/internal/router/listsize_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright (c) Intrinsec 2024
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewriteListSizes(t *testing.T) {
+	tests := map[string]struct {
+		in   int
+		want int
+	}{
+		"zero clamps to zero":             {in: 0, want: 0},
+		"below overhead clamps to zero":   {in: 5, want: 0},
+		"exactly overhead clamps to zero": {in: 28, want: 0},
+		"one byte plaintext":              {in: 29, want: 1},
+		"large object":                    {in: 1610890, want: 1610862},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			body := []byte(fmt.Sprintf("<Size>%d</Size>", tt.in))
+			got := rewriteListSizes(body)
+			assert.Equal(t, fmt.Sprintf("<Size>%d</Size>", tt.want), string(got))
+		})
+	}
+}
+
+// TestRewriteListSizesPreservesStructure asserts only <Size> values change; surrounding XML —
+// including CommonPrefixes (directories, which carry no <Size>) — is byte-for-byte preserved.
+func TestRewriteListSizesPreservesStructure(t *testing.T) {
+	body := []byte(`<?xml version="1.0" encoding="UTF-8"?>` +
+		`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+		`<Name>bucket</Name>` +
+		`<Contents><Key>a.txt</Key><Size>1610890</Size><ETag>"abc"</ETag></Contents>` +
+		`<Contents><Key>b.txt</Key><Size>28</Size></Contents>` +
+		`<CommonPrefixes><Prefix>dir/</Prefix></CommonPrefixes>` +
+		`</ListBucketResult>`)
+
+	want := []byte(`<?xml version="1.0" encoding="UTF-8"?>` +
+		`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+		`<Name>bucket</Name>` +
+		`<Contents><Key>a.txt</Key><Size>1610862</Size><ETag>"abc"</ETag></Contents>` +
+		`<Contents><Key>b.txt</Key><Size>0</Size></Contents>` +
+		`<CommonPrefixes><Prefix>dir/</Prefix></CommonPrefixes>` +
+		`</ListBucketResult>`)
+
+	assert.Equal(t, string(want), string(rewriteListSizes(body)))
+}
+
+func TestRewriteListSizesNoSizeElement(t *testing.T) {
+	body := []byte(`<ListBucketResult><CommonPrefixes><Prefix>dir/</Prefix></CommonPrefixes></ListBucketResult>`)
+	assert.Equal(t, string(body), string(rewriteListSizes(body)))
+}

--- a/s3proxy/internal/router/object.go
+++ b/s3proxy/internal/router/object.go
@@ -45,12 +45,6 @@ func releaseLargeBuffer(buf *[]byte) {
 	}
 }
 
-// s3OperationTimeout bounds the total duration of an individual S3 GetObject/PutObject call.
-// We detach from the request context (context.WithoutCancel) so a client disconnect does not
-// abort a partially-uploaded PutObject, but we still cap overall work to protect against
-// hung upstreams producing zombie requests.
-const s3OperationTimeout = 2 * time.Minute
-
 // object bundles data to implement http.Handler methods that use data from incoming requests.
 type object struct {
 	keks                      cryptoutil.KEKProvider
@@ -84,7 +78,7 @@ func (o object) get(w http.ResponseWriter, r *http.Request) {
 	// Detach from the request cancellation to avoid aborting an S3 operation when
 	// the client disconnects mid-flight, but cap the total duration so a hung
 	// upstream cannot produce a zombie request.
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), s3OperationTimeout)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), config.GetS3OperationTimeout())
 	defer cancel()
 
 	output, err := o.client.GetObject(ctx, o.bucket, o.key, o.versionID, o.sseCustomerAlgorithm, o.sseCustomerKey, o.sseCustomerKeyMD5)
@@ -211,7 +205,7 @@ func (o object) put(w http.ResponseWriter, r *http.Request) {
 	o.metadata[config.GetDekTagName()] = hex.EncodeToString(encryptedDEK)
 	o.metadata[config.GetKEKVersionTagName()] = kekVersion
 
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), s3OperationTimeout)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), config.GetS3OperationTimeout())
 	defer cancel()
 
 	output, err := o.client.PutObject(ctx, o.bucket, o.key, o.tags, o.contentType, o.objectLockLegalHoldStatus, o.objectLockMode, o.sseCustomerAlgorithm, o.sseCustomerKey, o.sseCustomerKeyMD5, o.objectLockRetainUntilDate, o.metadata, ciphertext)

--- a/s3proxy/internal/router/object.go
+++ b/s3proxy/internal/router/object.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -157,6 +158,11 @@ func (o object) get(w http.ResponseWriter, r *http.Request) {
 		releaseLargeBuffer(&plaintext)
 		return
 	default:
+		// The full plaintext is already buffered, so emit an explicit Content-Length
+		// (the upstream value describes the ciphertext, not the decrypted body) so the
+		// server uses identity encoding instead of chunked. Some clients (e.g. s3cmd)
+		// require a Content-Length header on the response.
+		w.Header().Set("Content-Length", strconv.Itoa(len(plaintext)))
 		w.WriteHeader(http.StatusOK)
 		_, writeErr := w.Write(plaintext)
 		releaseLargeBuffer(&plaintext)

--- a/s3proxy/internal/router/object.go
+++ b/s3proxy/internal/router/object.go
@@ -9,6 +9,7 @@ package router
 
 import (
 	"context"
+	"crypto/md5"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -149,6 +150,14 @@ func (o object) get(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed to decrypt object", http.StatusInternalServerError)
 			return
 		}
+
+		// The upstream ETag is S3's MD5 of the ciphertext at rest, which does not
+		// match the decrypted body we deliver. Override it with the plaintext MD5
+		// so clients that validate or cache by ETag see a consistent value. Single
+		// part only (multipart is blocked/forwarded), so ETag == hex(md5(content)).
+		//nolint:gosec // MD5 is not used as a security primitive here; it is the S3 ETag definition.
+		sum := md5.Sum(plaintext)
+		w.Header().Set("ETag", hex.EncodeToString(sum[:]))
 	}
 
 	select {

--- a/s3proxy/internal/router/router.go
+++ b/s3proxy/internal/router/router.go
@@ -43,7 +43,40 @@ import (
 
 var (
 	bucketAndKeyPattern = regexp.MustCompile("/([^/?]+)/(.+)")
+	// bucketOnlyPattern matches a bucket-level path (no object key), with an optional
+	// trailing slash. Used to detect ListObjects/ListObjectsV2 requests.
+	bucketOnlyPattern = regexp.MustCompile("^/([^/?]+)/?$")
 )
+
+// listSubResourceMarkers are query parameters that turn a bucket-level GET into a
+// sub-resource request (bucket ACL, versioning, multipart listing, …). Those return
+// XML that has no <Contents><Size>, or is out of scope (versions), so they must not be
+// rewritten — only a "clean" ListObjects v1/v2 carries object sizes.
+var listSubResourceMarkers = []string{
+	"acl", "policy", "versioning", "location", "tagging", "lifecycle", "cors",
+	"website", "replication", "encryption", "object-lock", "accelerate", "analytics",
+	"intelligent-tiering", "inventory", "metrics", "logging", "notification",
+	"ownershipControls", "publicAccessBlock", "requestPayment", "uploads", "versions",
+}
+
+// isListObjects reports whether req is a clean ListObjects (v1) or ListObjectsV2 request,
+// i.e. a bucket-level GET with no sub-resource marker query parameters. Both v1 (no
+// list-type) and v2 (list-type=2) match.
+func isListObjects(req *http.Request) bool {
+	if req.Method != http.MethodGet {
+		return false
+	}
+	if !bucketOnlyPattern.MatchString(req.URL.Path) {
+		return false
+	}
+	query := req.URL.Query()
+	for _, marker := range listSubResourceMarkers {
+		if _, ok := query[marker]; ok {
+			return false
+		}
+	}
+	return true
+}
 
 // Router implements the interception logic for the s3proxy.
 type Router struct {
@@ -374,8 +407,12 @@ func (r Router) getHandler(req *http.Request, client s3Client, matchingPath bool
 		})
 	}
 
-	// Forward if path doesn't match
+	// Forward if path doesn't match. Bucket-level ListObjects requests land here (they have
+	// no object key); intercept them to report decrypted plaintext sizes.
 	if !matchingPath {
+		if s3Client, ok := client.(*s3.Client); ok && isListObjects(req) {
+			return handleListObjects(s3Client, r.log, r.metrics)
+		}
 		return forwardHandler()
 	}
 

--- a/s3proxy/internal/router/router_test.go
+++ b/s3proxy/internal/router/router_test.go
@@ -8,6 +8,7 @@ package router
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"encoding/hex"
 	"io"
 	"log/slog"
@@ -196,6 +197,49 @@ func TestGetObjectUsesRouterKEK(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "secret payload", rec.Body.String())
+}
+
+func TestGetObjectReturnsPlaintextETag(t *testing.T) {
+	keks := newTestKEKs(t, "expected encryption key")
+	version, curKEK := keks.Current()
+	plaintext := []byte("secret payload")
+	client := newEncryptedGetObjectClient(t, curKEK, version, plaintext)
+	// Upstream ETag describes the ciphertext at rest, not the body we deliver.
+	upstreamETag := "\"deadbeefdeadbeefdeadbeefdeadbeef\""
+	client.getObjectOut.ETag = &upstreamETag
+	router := Router{keks: keks, log: testLogger()}
+	req := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)
+	rec := httptest.NewRecorder()
+
+	router.getHandler(req, client, true, "key", "bucket").ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	want := md5.Sum(plaintext)
+	assert.Equal(t, hex.EncodeToString(want[:]), rec.Header().Get("ETag"))
+	assert.NotEqual(t, strings.Trim(upstreamETag, "\""), rec.Header().Get("ETag"))
+}
+
+func TestGetObjectPassThroughKeepsUpstreamETag(t *testing.T) {
+	// No DEK metadata tag: the object was not proxy-encrypted, so the upstream
+	// ETag already describes the bytes we deliver and must be left untouched.
+	body := []byte("plain passthrough")
+	upstreamETag := "\"deadbeefdeadbeefdeadbeefdeadbeef\""
+	client := &recordingS3Client{
+		getObjectOut: &s3.GetObjectOutput{
+			Body:          io.NopCloser(bytes.NewReader(body)),
+			ContentLength: awsInt64(int64(len(body))),
+			ETag:          &upstreamETag,
+		},
+	}
+	router := Router{keks: newTestKEKs(t, "expected encryption key"), log: testLogger()}
+	req := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)
+	rec := httptest.NewRecorder()
+
+	router.getHandler(req, client, true, "key", "bucket").ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, body, rec.Body.Bytes())
+	assert.Equal(t, strings.Trim(upstreamETag, "\""), rec.Header().Get("ETag"))
 }
 
 func TestGetObjectFailsWithWrongRouterKEK(t *testing.T) {

--- a/s3proxy/internal/router/router_test.go
+++ b/s3proxy/internal/router/router_test.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -196,6 +197,35 @@ func TestGetObjectUsesRouterKEK(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "secret payload", rec.Body.String())
+}
+
+func TestGetObjectSetsPlaintextContentLength(t *testing.T) {
+	keks := newTestKEKs(t, "expected encryption key")
+	version, curKEK := keks.Current()
+	client := newEncryptedGetObjectClient(t, curKEK, version, []byte("secret payload"))
+	router := Router{keks: keks, log: testLogger()}
+	req := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)
+	rec := httptest.NewRecorder()
+
+	router.getHandler(req, client, true, "key", "bucket").ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	// The header must reflect the plaintext length, not the +28-byte ciphertext.
+	assert.Equal(t, strconv.Itoa(len("secret payload")), rec.Result().Header.Get("Content-Length"))
+}
+
+func TestGetObjectSetsZeroContentLengthForEmptyObject(t *testing.T) {
+	keks := newTestKEKs(t, "expected encryption key")
+	version, curKEK := keks.Current()
+	client := newEncryptedGetObjectClient(t, curKEK, version, []byte{})
+	router := Router{keks: keks, log: testLogger()}
+	req := httptest.NewRequest(http.MethodGet, "/bucket/key", nil)
+	rec := httptest.NewRecorder()
+
+	router.getHandler(req, client, true, "key", "bucket").ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "0", rec.Result().Header.Get("Content-Length"))
 }
 
 func TestGetObjectFailsWithWrongRouterKEK(t *testing.T) {


### PR DESCRIPTION
Integration branch bundling the five reviewed PRs, with conflicts resolved and the release metadata applied.

## Included

| PR | Change |
|----|--------|
| #49 | `Content-Length` on intercepted GetObject (fixes s3cmd downloading empty files) |
| #50 | Plaintext `ETag` on intercepted GetObject |
| #51 | Decrypted plaintext sizes in `ListObjects`/`ListObjectsV2` |
| #53 | Configurable `S3PROXY_S3_OPERATION_TIMEOUT` |
| #54 | Chart `deploymentAnnotations` (Reloader on the Deployment) |

**#52 (buffered multipart) is deliberately excluded** — it is a 2612-line change to the crypto path that warrants its own review pass. See the notes below.

## Conflicts resolved

Merging these in sequence is not clean; the resolutions here are:

- `router_test.go` (#49 × #50) — the two test additions interleave inside function bodies. Resolved by keeping all four tests: `TestGetObjectSetsPlaintextContentLength`, `TestGetObjectSetsZeroContentLengthForEmptyObject`, `TestGetObjectReturnsPlaintextETag`, `TestGetObjectPassThroughKeepsUpstreamETag`.
- `CHANGELOG.md` (#50, #51, #53) — additive; entries kept and the duplicated `### Added` headings collapsed into one.

## Release metadata

- `CHANGELOG.md`: `[Unreleased]` → `[1.9.0] — 2026-07-29`, fresh empty `[Unreleased]` on top.
- `charts/s3proxy/Chart.yaml`: `appVersion` `1.8.1` → `1.9.0`; chart `version` `1.10.0` (from #54).

Once merged, the two release tags are `v1.9.0` (app → Docker image + signed binaries) and `chart-v1.10.0` (chart → ghcr push).

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — 108 tests pass across 7 packages
- `gofmt -l .` — clean
- `helm lint charts/s3proxy` — passes

`golangci-lint` locally reports 12 goconst issues vs 11 on `main` — the one addition is `"valid"` in `internal/config/validation_test.go` from #53's test table. Note the local linter is v2.12.2 while CI pins v2.11.4, under which `main`'s existing 11 do not fire; goconst's test-file handling changed between those versions.

## Review notes on the included PRs

Not blocking, worth tracking:

- **#51** — `bucketOnlyPattern` (`^/([^/?]+)/?$`) only matches path-style addressing, so virtual-host-style list requests are not rewritten. If an upstream ever returns a gzip-encoded list body, the regex silently matches nothing.
- **#53** — an out-of-range `S3PROXY_S3_OPERATION_TIMEOUT` silently falls back to 120s. Setting `3600` looks accepted but yields 2 minutes; a startup warning or hard failure would be safer.
- **#50** — the `ETag` is emitted unquoted, which deviates from RFC 9110 / S3. This matches the pre-existing convention on the PUT path (`object.go:279`), so it is not a regression, but both are worth aligning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)